### PR TITLE
Default 500 Error Catching

### DIFF
--- a/app/routes/authentication.py
+++ b/app/routes/authentication.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Response
 from app.utils.auth import Auth, users_db, ACCESS_TOKEN_EXPIRE_MINUTES, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 from gvm.connections import UnixSocketConnection
 from typing import Annotated
@@ -50,7 +51,10 @@ async def describe_auth(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return XMLResponse(gmp.describe_auth())
+        try:
+            return XMLResponse(gmp.describe_auth())
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/is_authenticated", response_class=XMLResponse)
 async def is_authenticated(
@@ -67,8 +71,11 @@ async def is_authenticated(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        response = str(gmp.is_authenticated())
-        return XMLResponse(f'<is_authenticated_response status="200" status_text="{response}"/>')
+        try:
+            response = str(gmp.is_authenticated())
+            return XMLResponse(f'<is_authenticated_response status="200" status_text="{response}"/>')
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.patch("/modify_auth", response_class=XMLResponse)
 async def modify_auth(
@@ -88,4 +95,7 @@ async def modify_auth(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return XMLResponse(gmp.modify_auth(group_name=group_name, auth_conf_settings=auth_conf_settings))
+        try:
+            return XMLResponse(gmp.modify_auth(group_name=group_name, auth_conf_settings=auth_conf_settings))
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/credential.py
+++ b/app/routes/credential.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, Body
 from app import LOGGING_PREFIX
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 from gvm.connections import UnixSocketConnection
 from gvm.errors import RequiredArgument
@@ -77,8 +78,8 @@ def create_credential(
         gmp.authenticate(username=current_user.username, password=PASSWORD)
         try:
             return gmp.create_credential(name=name,credential_type=credential_type,comment=comment,allow_insecure=allow_insecure,certificate=certificate,key_phrase=key_phrase,private_key=private_key,login=login,password=password,auth_algorithm=auth_algorithm,community=community,privacy_algorithm=privacy_algorithm,privacy_password=privacy_password,public_key=public_key)
-        except RequiredArgument as err:
-            return f'<create_credential_response status="500" status_text="{err}"/>'
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/credential")
 def get_credential(
@@ -102,8 +103,11 @@ def get_credential(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_credential(credential_id=credential_id,scanners=scanners,targets=targets,credential_format=credential_format)
-    
+        try:
+            return gmp.get_credential(credential_id=credential_id,scanners=scanners,targets=targets,credential_format=credential_format)
+        except Exception as err:
+            return ErrorResponse(err)
+
 @ROUTER.get("/get/credentials")
 def get_credentials(
     current_user: Annotated[Auth.User, Depends(Auth.get_current_active_user)],
@@ -128,8 +132,11 @@ def get_credentials(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_credentials(filter_string=filter_string,filter_id=filter_id,scanners=scanners,trash=trash,targets=targets)
-    
+        try:
+            return gmp.get_credentials(filter_string=filter_string,filter_id=filter_id,scanners=scanners,trash=trash,targets=targets)
+        except Exception as err:
+            return ErrorResponse(err)
+
 @ROUTER.post("/clone/credential")
 def clone_credential(
     current_user: Annotated[Auth.User, Depends(Auth.get_current_active_user)],
@@ -146,7 +153,10 @@ def clone_credential(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.clone_credential(credential_id=credential_id)
+        try:
+            return gmp.clone_credential(credential_id=credential_id)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.delete("/delete/credential")
 def delete_credential(
@@ -163,7 +173,10 @@ def delete_credential(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_credential(credential_id=credential_id, ultimate=ultimate)
+        try:
+            return gmp.delete_credential(credential_id=credential_id, ultimate=ultimate)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.patch("/modify/credential")
 def modify_credential(
@@ -209,5 +222,5 @@ def modify_credential(
         gmp.authenticate(username=current_user.username, password=PASSWORD)
         try:
             return gmp.modify_credential(name=name,credential_id=credential_id,comment=comment,allow_insecure=allow_insecure,certificate=certificate,key_phrase=key_phrase,private_key=private_key,login=login,password=password,auth_algorithm=auth_algorithm,community=community,privacy_algorithm=privacy_algorithm,privacy_password=privacy_password,public_key=public_key)
-        except RequiredArgument as err:
-            return f'<modify_credential_response status="500" status_text="{err}"/>'
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/feed.py
+++ b/app/routes/feed.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -31,7 +32,10 @@ async def get_feeds(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_feeds()
+        try:
+            return gmp.get_feeds()
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/feed")
 async def get_feed(
@@ -49,5 +53,8 @@ async def get_feed(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_feed(feed_type=feed_type)
+        try:
+            return gmp.get_feed(feed_type=feed_type)
+        except Exception as err:
+            return ErrorResponse(err)
     

--- a/app/routes/port.py
+++ b/app/routes/port.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -44,7 +45,10 @@ async def get_port_lists(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_port_lists(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details,targets=targets)
+        try:
+            return gmp.get_port_lists(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details,targets=targets)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/port/list")
 async def get_port_list(
@@ -62,7 +66,10 @@ async def get_port_list(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_port_list(port_list_id=port_list_id)
+        try:
+            return gmp.get_port_list(port_list_id=port_list_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/clone/port/list")
 async def clone_port_list(
@@ -80,7 +87,10 @@ async def clone_port_list(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.clone_port_list(port_list_id=port_list_id)
+        try:
+            return gmp.clone_port_list(port_list_id=port_list_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/create/port/list")
 async def create_port_list(
@@ -102,7 +112,10 @@ async def create_port_list(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.create_port_list(name=name, port_range=port_range, comment=comment)
+        try:
+            return gmp.create_port_list(name=name, port_range=port_range, comment=comment)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/create/port/range")
 async def create_port_range(
@@ -128,7 +141,10 @@ async def create_port_range(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return  gmp.create_port_range(port_list_id=port_list_id,start=start,end=end,port_range_type=port_range_type,comment=comment)
+        try:
+            return gmp.create_port_range(port_list_id=port_list_id,start=start,end=end,port_range_type=port_range_type,comment=comment)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.delete("/delete/port/list")
 async def delete_port_list(
@@ -145,7 +161,10 @@ async def delete_port_list(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_port_list(port_list_id=port_list_id, ultimate=ultimate)
+        try:
+            return gmp.delete_port_list(port_list_id=port_list_id, ultimate=ultimate)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.delete("/delete/port/range")
 async def delete_port_range(
@@ -160,7 +179,10 @@ async def delete_port_range(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_port_range(port_range_id=port_range_id)
+        try:
+            return gmp.delete_port_range(port_range_id=port_range_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.patch("/modify/port/list")
 async def modify_port_list(
@@ -182,4 +204,7 @@ async def modify_port_list(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.modify_port_list(port_list_id=port_list_id, comment=comment, name=name)
+        try:
+            return gmp.modify_port_list(port_list_id=port_list_id, comment=comment, name=name)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/report.py
+++ b/app/routes/report.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -48,7 +49,10 @@ async def get_report(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=details)
+        try:
+            return gmp.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=details)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/reports")
 async def get_reports(
@@ -76,7 +80,10 @@ async def get_reports(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_reports(filter_string=filter_string,filter_id=filter_id,note_details=note_details,override_details=override_details,ignore_pagination=ignore_pagination,details=details)
+        try:
+            return gmp.get_reports(filter_string=filter_string,filter_id=filter_id,note_details=note_details,override_details=override_details,ignore_pagination=ignore_pagination,details=details)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/report/format")
 async def get_report_format(
@@ -93,7 +100,10 @@ async def get_report_format(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_report_format(report_format_id=report_format_id)
+        try:
+            return gmp.get_report_format(report_format_id=report_format_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/report/formats")
 async def get_report_formats(
@@ -115,7 +125,10 @@ async def get_report_formats(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_report_formats(filter_string=filter_string,filter_id=filter_id,trash=trash,alerts=alerts,params=params,details=details)
+        try:
+            return gmp.get_report_formats(filter_string=filter_string,filter_id=filter_id,trash=trash,alerts=alerts,params=params,details=details)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/clone/report/formats")
 async def get_report_formats(
@@ -133,7 +146,10 @@ async def get_report_formats(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.clone_report_format(report_format_id=report_format_id)
+        try:
+            return gmp.clone_report_format(report_format_id=report_format_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.delete("/delete/report")
 async def delete_report(
@@ -148,7 +164,10 @@ async def delete_report(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_report(report_id=report_id)
+        try:
+            return gmp.delete_report(report_id=report_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.delete("/delete/report/format")
 async def delete_report(
@@ -166,7 +185,10 @@ async def delete_report(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_report_format(report_format_id=report_format_id)
+        try:
+            return gmp.delete_report_format(report_format_id=report_format_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/import/report")
 async def import_report(
@@ -188,7 +210,10 @@ async def import_report(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.import_report(report=report,task_id=task_id,in_assets=in_assets)
+        try:
+            return gmp.import_report(report=report,task_id=task_id,in_assets=in_assets)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/import/report/format")
 async def import_report_format(
@@ -206,7 +231,10 @@ async def import_report_format(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.import_report_format(report_format=report_format)
+        try:
+            return gmp.import_report_format(report_format=report_format)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.patch("/modify/report/format")
 async def modify_report_format(
@@ -234,7 +262,10 @@ async def modify_report_format(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.modify_report_format(report_format_id=report_format_id,active=active,name=name,summary=summary,param_name=param_name,param_value=param_value)
+        try:
+            return gmp.modify_report_format(report_format_id=report_format_id,active=active,name=name,summary=summary,param_name=param_name,param_value=param_value)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/verify/report/format")
 async def verify_report_format(
@@ -258,7 +289,10 @@ async def verify_report_format(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.verify_report_format(report_format_id=report_format_id)
+        try:
+            return gmp.verify_report_format(report_format_id=report_format_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/system/reports")
 async def get_system_reports(
@@ -287,4 +321,7 @@ async def get_system_reports(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_system_reports(name=name,duration=duration,start_time=start_time,end_time=end_time,brief=brief,slave_id=slave_id)
+        try:
+            return gmp.get_system_reports(name=name,duration=duration,start_time=start_time,end_time=end_time,brief=brief,slave_id=slave_id)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/scan.py
+++ b/app/routes/scan.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -47,7 +48,10 @@ async def get_scan_configs(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_scan_configs(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details,families=families,preferences=preferences,tasks=tasks)
+        try:
+            return gmp.get_scan_configs(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details,families=families,preferences=preferences,tasks=tasks)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/scanners", deprecated=True)
 async def get_scanners(
@@ -71,4 +75,7 @@ async def get_scanners(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return Response(content=gmp.get_scanners(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details), media_type="application/xml")
+        try:
+            return Response(content=gmp.get_scanners(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details), media_type="application/xml")
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/scanner.py
+++ b/app/routes/scanner.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -41,4 +42,7 @@ async def get_scanners(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_scanners(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details)
+        try:
+            return gmp.get_scanners(filter_string=filter_string,filter_id=filter_id,trash=trash,details=details)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/target.py
+++ b/app/routes/target.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -67,8 +68,8 @@ async def create_target(
         gmp.authenticate(username=current_user.username, password=PASSWORD)
         try:
             return gmp.create_target(name=name,asset_hosts_filter=asset_hosts_filter,hosts=hosts,comment=comment,exclude_hosts=exclude_hosts,ssh_credential_id=ssh_credential_id,ssh_credential_port=ssh_credential_port,smb_credential_id=smb_credential_id,esxi_credential_id=esxi_credential_id,snmp_credential_id=snmp_credential_id,alive_test=alive_test,reverse_lookup_only=reverse_lookup_only,reverse_lookup_unify=reverse_lookup_unify,port_range=port_range,port_list_id=port_list_id)
-        except RequiredArgument as err:
-            return f'<create_target_response status="500" status_text="{err}"/>'
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/target")
 async def get_target(
@@ -88,7 +89,10 @@ async def get_target(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_target(target_id=target_id, tasks=tasks)
+        try:
+            return gmp.get_target(target_id=target_id, tasks=tasks)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.get("/get/targets")
 async def get_targets(
@@ -112,7 +116,10 @@ async def get_targets(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_targets(filter_string=filter_string,filter_id=filter_id,trash=trash,tasks=tasks)
+        try:
+            return gmp.get_targets(filter_string=filter_string,filter_id=filter_id,trash=trash,tasks=tasks)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.post("/clone/target")
 async def clone_target(
@@ -130,7 +137,10 @@ async def clone_target(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.clone_target(target_id=target_id)
+        try:
+            return gmp.clone_target(target_id=target_id)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.delete("/delete/target")
 async def delete_target(
@@ -147,7 +157,10 @@ async def delete_target(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_target(target_id=target_id, ultimate=ultimate)
+        try:
+            return gmp.delete_target(target_id=target_id, ultimate=ultimate)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.patch("/modify/target")
 async def delete_target(
@@ -193,4 +206,7 @@ async def delete_target(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.modify_target(target_id=target_id,name=name,comment=comment,hosts=hosts,exclude_hosts=exclude_hosts,ssh_credential_id=ssh_credential_id,ssh_credential_port=ssh_credential_port,smb_credential_id=smb_credential_id,esxi_credential_id=esxi_credential_id,snmp_credential_id=snmp_credential_id,alive_test=alive_test,allow_simultaneous_ips=allow_simultaneous_ips,reverse_lookup_only=reverse_lookup_only,reverse_lookup_unify=reverse_lookup_unify,port_list_id=port_list_id)
+        try:
+            return gmp.modify_target(target_id=target_id,name=name,comment=comment,hosts=hosts,exclude_hosts=exclude_hosts,ssh_credential_id=ssh_credential_id,ssh_credential_port=ssh_credential_port,smb_credential_id=smb_credential_id,esxi_credential_id=esxi_credential_id,snmp_credential_id=snmp_credential_id,alive_test=alive_test,allow_simultaneous_ips=allow_simultaneous_ips,reverse_lookup_only=reverse_lookup_only,reverse_lookup_unify=reverse_lookup_unify,port_list_id=port_list_id)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/task.py
+++ b/app/routes/task.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -44,7 +45,10 @@ async def get_tasks(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_tasks(filter_string=filter_string, filter_id=filter_id, trash=trash, details=details, schedules_only=schedules_only)
+        try:
+            return gmp.get_tasks(filter_string=filter_string, filter_id=filter_id, trash=trash, details=details, schedules_only=schedules_only)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/task", tags=["task"])
 async def get_task(
@@ -62,7 +66,10 @@ async def get_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_task(task_id)
+        try:
+            return gmp.get_task(task_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.delete("/delete/task", tags=["task"])
 async def delete_task(
@@ -79,7 +86,10 @@ async def delete_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.delete_task(task_id=task_id, ultimate=ultimate)
+        try:
+            return gmp.delete_task(task_id=task_id, ultimate=ultimate)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/create/task", tags=["task"])
 async def create_task(
@@ -119,7 +129,10 @@ async def create_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.create_task(name=name,config_id=config_id,target_id=target_id,scanner_id=scanner_id,alterable=alterable,hosts_ordering=hosts_ordering,schedule_id=schedule_id,alert_ids=alert_ids,comment=comment,schedule_periods=schedule_periods,observers=observers,preferences=preferences)
+        try:
+            return gmp.create_task(name=name,config_id=config_id,target_id=target_id,scanner_id=scanner_id,alterable=alterable,hosts_ordering=hosts_ordering,schedule_id=schedule_id,alert_ids=alert_ids,comment=comment,schedule_periods=schedule_periods,observers=observers,preferences=preferences)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.patch("/modify/task", tags=["task"])
 async def modify_task(
@@ -160,7 +173,10 @@ async def modify_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.modify_task(task_id=task_id,name=name,config_id=config_id,target_id=target_id,scanner_id=scanner_id,alterable=alterable,hosts_ordering=hosts_ordering,schedule_id=schedule_id,schedule_periods=schedule_periods,comment=comment,alert_ids=alert_ids,observers=observers,preferences=preferences)
+        try:
+            return gmp.modify_task(task_id=task_id,name=name,config_id=config_id,target_id=target_id,scanner_id=scanner_id,alterable=alterable,hosts_ordering=hosts_ordering,schedule_id=schedule_id,schedule_periods=schedule_periods,comment=comment,alert_ids=alert_ids,observers=observers,preferences=preferences)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/stop/task", tags=["task"])
 async def stop_task(
@@ -178,7 +194,10 @@ async def stop_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.stop_task(task_id=task_id)
+        try:
+            return gmp.stop_task(task_id=task_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/start/task", tags=["task"])
 async def start_task(
@@ -196,7 +215,10 @@ async def start_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.start_task(task_id=task_id)
+        try:
+            return gmp.start_task(task_id=task_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/clone/task", tags=["task"])
 async def clone_task(
@@ -214,7 +236,10 @@ async def clone_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.clone_task(task_id=task_id)
+        try:
+            return gmp.clone_task(task_id=task_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.patch("/move/task", tags=["task"])
 async def move_task(
@@ -234,7 +259,10 @@ async def move_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.move_task(task_id=task_id, slave_id=slave_id)
+        try:
+            return gmp.move_task(task_id=task_id, slave_id=slave_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.post("/resume/task", tags=["task"])
 async def resume_task(
@@ -252,4 +280,7 @@ async def resume_task(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.resume_task(task_id=task_id)
+        try:
+            return gmp.resume_task(task_id=task_id)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from app.utils.auth import Auth, PASSWORD
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -35,7 +36,10 @@ async def get_user(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_user(user_id=user_id)
+        try:
+            return gmp.get_user(user_id=user_id)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/user/settings")
 async def get_user_settings(
@@ -53,7 +57,10 @@ async def get_user_settings(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_user_settings(filter_string=filter_string)
+        try:
+            return gmp.get_user_settings(filter_string=filter_string)
+        except Exception as err:
+            return ErrorResponse(err)
 
 @ROUTER.get("/get/user/setting")
 async def get_user_setting(
@@ -71,7 +78,10 @@ async def get_user_setting(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_user_setting(setting_id=setting_id)
+        try:
+            return gmp.get_user_setting(setting_id=setting_id)
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.get("/get/users")
 async def get_users(
@@ -91,4 +101,7 @@ async def get_users(
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
         gmp.authenticate(username=current_user.username, password=PASSWORD)
-        return gmp.get_users(filter_id=filter_id, filter_string=filter_string)
+        try:
+            return gmp.get_users(filter_id=filter_id, filter_string=filter_string)
+        except Exception as err:
+            return ErrorResponse(err)

--- a/app/routes/version.py
+++ b/app/routes/version.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 from app.utils.auth import Auth
 from app.utils.xml import XMLResponse
+from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
 import logging
 from gvm.connections import UnixSocketConnection
@@ -29,7 +30,10 @@ async def get_version(
             The response.
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
-        return gmp.get_version()
+        try:
+            return gmp.get_version()
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.get("/get/protocol/version")
 async def get_protocol_version(
@@ -41,8 +45,11 @@ async def get_protocol_version(
             tuple: Implemented version of the Greenbone Management Protocol
         """
     with Gmp(connection=UnixSocketConnection()) as gmp:
-        content = str(gmp.get_protocol_version())
-        return Response(content=content, media_type="application/xml")
+        try:
+            content = str(gmp.get_protocol_version())
+            return Response(content=content, media_type="application/xml")
+        except Exception as err:
+            return ErrorResponse(err)
     
 @ROUTER.get("/get/api/version")
 async def get_api_version(

--- a/app/utils/error.py
+++ b/app/utils/error.py
@@ -1,0 +1,9 @@
+from typing import Any
+from .xml import XMLResponse
+
+class ErrorResponse(XMLResponse):
+
+    def render(self, content: Any) -> bytes:
+        self.status_code = 500
+        resp_content = f'<error_response status="500" status_text="{content}"/>'
+        return super().render(resp_content)


### PR DESCRIPTION
All GMP calls now in try / except catching any errors that arise and passing them back to user as a 500 with the error response.

This also resolves any error where the API requires an optional input based on another input. Relates to #86 and #77. It would have also helped bug find some other endpoints.