### PR TITLE
Fix: Empty report connection error with retry logic

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -15,84 +15,96 @@ services:
       - gvmd
       - redis-db
     command: sleep infinity
-  # redis:
-  #   image: redis/redis-stack:7.2.0-v9
-  #   restart: unless-stopped
-  #   environment:
-  #     - REDIS_ARGS=--appendonly yes
-  #   # volumes:
-  #   #   - redis-data:/data
-  #   ports:
-  #     - 8001:8001
+
   vulnerability-tests:
-    image: greenbone/vulnerability-tests:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/vulnerability-tests:2026-03-30
     environment:
-      STORAGE_PATH: /var/lib/openvas/22.04/vt-data/nasl
+      FEED_RELEASE: "24.10"
+      KEEP_ALIVE: 1
     volumes:
       - vt_data_vol:/mnt
 
   notus-data:
-    image: greenbone/notus-data:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/notus-data:2026-03-30
+    environment:
+      KEEP_ALIVE: 1
     volumes:
       - notus_data_vol:/mnt
 
   scap-data:
-    image: greenbone/scap-data:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/scap-data:2026-03-30
+    environment:
+      KEEP_ALIVE: 1
     volumes:
       - scap_data_vol:/mnt
 
   cert-bund-data:
-    image: greenbone/cert-bund-data:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/cert-bund-data:2026-03-30
+    environment:
+      KEEP_ALIVE: 1
     volumes:
       - cert_data_vol:/mnt
 
   dfn-cert-data:
-    image: greenbone/dfn-cert-data:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/dfn-cert-data:2026-03-30
+    environment:
+      KEEP_ALIVE: 1
     volumes:
       - cert_data_vol:/mnt
     depends_on:
-      - cert-bund-data
+      cert-bund-data:
+        condition: service_healthy
 
   data-objects:
-    image: greenbone/data-objects:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/data-objects:2026-03-30
+    environment:
+      FEED_RELEASE: "24.10"
+      KEEP_ALIVE: 1
     volumes:
       - data_objects_vol:/mnt
 
   report-formats:
-    image: greenbone/report-formats:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/report-formats:2026-03-30
+    environment:
+      FEED_RELEASE: "24.10"
+      KEEP_ALIVE: 1
     volumes:
       - data_objects_vol:/mnt
     depends_on:
-      - data-objects
+      data-objects:
+        condition: service_healthy
 
   gpg-data:
-    image: greenbone/gpg-data:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/gpg-data:2026-03-30
     volumes:
       - gpg_data_vol:/mnt
 
   redis-server:
-    image: greenbone/redis-server:latest
+    image: ghcr.io/shield-cyber/greenbone/redis-server:2026-03-30
     restart: on-failure
     volumes:
       - redis_socket_vol:/run/redis/
 
   pg-gvm:
-    image: greenbone/pg-gvm:stable
+    image: ghcr.io/shield-cyber/greenbone/pg-gvm:2026-03-30
     restart: on-failure
+    stop_grace_period: 60s
+    volumes:
+      - psql_data_vol:/var/lib/postgresql
+      - psql_socket_vol:/var/run/postgresql
+    depends_on:
+      pg-gvm-migrator:
+        condition: service_completed_successfully
+
+  pg-gvm-migrator:
+    image: ghcr.io/shield-cyber/greenbone/pg-gvm-migrator:2026-03-30
+    restart: no
     volumes:
       - psql_data_vol:/var/lib/postgresql
       - psql_socket_vol:/var/run/postgresql
 
   gvmd:
-    image: greenbone/gvmd:stable
+    image: ghcr.io/shield-cyber/greenbone/gvmd:2026-03-30
     restart: on-failure
     environment:
       - USERNAME=admin # DEFAULT USERNAME 'admin'
@@ -111,30 +123,135 @@ services:
       pg-gvm:
         condition: service_started
       scap-data:
-        condition: service_completed_successfully
+        condition: service_healthy
       cert-bund-data:
-        condition: service_completed_successfully
+        condition: service_healthy
       dfn-cert-data:
-        condition: service_completed_successfully
+        condition: service_healthy
       data-objects:
-        condition: service_completed_successfully
+        condition: service_healthy
       report-formats:
-        condition: service_completed_successfully
+        condition: service_healthy
 
   gsa:
-    image: greenbone/gsa:stable
+    image: ghcr.io/shield-cyber/greenbone/gsa:2026-03-30
+    environment:
+      MOUNT_PATH: "/mnt/web"
+      KEEP_ALIVE: 1
+    healthcheck:
+      test: ["CMD-SHELL", "test -e /run/gsa/copying.done"]
+      start_period: 5s
+    volumes:
+      - gsa_data_vol:/mnt/web
+
+  gsad:
+    image: ghcr.io/shield-cyber/greenbone/gsad:2026-03-30
     restart: on-failure
-    ports:
-      - 9392:80
+    environment:
+      GSAD_ARGS: "--listen=0.0.0.0 --http-only --api-only -f"
     volumes:
       - gvmd_socket_vol:/run/gvmd
     depends_on:
-      - gvmd
+      gvmd:
+        condition: service_started
+
+  gvm-config:
+    image: ghcr.io/shield-cyber/greenbone/gvm-config:2026-03-30
+    environment:
+      ENABLE_NGINX_CONFIG: true
+      ENABLE_TLS_GENERATION: true
+    volumes:
+      - nginx_config_vol:/mnt/nginx/configs
+      - nginx_certificates_vol:/mnt/nginx/certs
+
+  nginx:
+    image: ghcr.io/shield-cyber/greenbone/nginx:2026-03-30
+    restart: on-failure
+    ports:
+      - 443:443
+      - 9392:9392
+    volumes:
+      - nginx_config_vol:/etc/nginx/conf.d:ro
+      - nginx_certificates_vol:/etc/nginx/certs:ro
+      - gsa_data_vol:/usr/share/nginx/html:ro
+    depends_on:
+      gvm-config:
+        condition: service_completed_successfully
+      gsa:
+        condition: service_healthy
+      gsad:
+        condition: service_started
+
+  # Sets log level of openvas to the set LOG_LEVEL within the env
+  # and changes log output to /var/log/openvas instead /var/log/gvm
+  # to reduce likelihood of unwanted log interferences
+  configure-openvas:
+    image: ghcr.io/shield-cyber/greenbone/openvas-scanner:2026-03-30
+    volumes:
+      - openvas_data_vol:/mnt
+      - openvas_log_data_vol:/var/log/openvas
+    command:
+      - /bin/sh
+      - -c
+      - |
+        printf "table_driven_lsc = yes\nopenvasd_server = http://openvasd:80\n" > /mnt/openvas.conf
+        sed 's/gvm/openvas/' /etc/openvas/openvas_log.conf > /mnt/openvas_log.conf
+        chmod 644 /mnt/openvas.conf
+        chmod 644 /mnt/openvas_log.conf
+        touch /var/log/openvas/openvas.log
+        chmod 666 /var/log/openvas/openvas.log
+
+  # shows logs of openvas
+  openvas:
+    image: ghcr.io/shield-cyber/greenbone/openvas-scanner:2026-03-30
+    restart: on-failure
+    volumes:
+      - openvas_data_vol:/etc/openvas
+      - openvas_log_data_vol:/var/log/openvas
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cat /etc/openvas/openvas.conf
+        tail -f /var/log/openvas/openvas.log
+    depends_on:
+      configure-openvas:
+        condition: service_completed_successfully
+
+  openvasd:
+    image: ghcr.io/shield-cyber/greenbone/openvas-scanner:2026-03-30
+    restart: on-failure
+    environment:
+      # `service_notus` is set to disable everything but notus,
+      # if you want to utilize openvasd directly, remove `OPENVASD_MODE`
+      OPENVASD_MODE: service_notus
+      GNUPGHOME: /etc/openvas/gnupg
+      LISTENING: 0.0.0.0:80
+    volumes:
+      - openvas_data_vol:/etc/openvas
+      - openvas_log_data_vol:/var/log/openvas
+      - gpg_data_vol:/etc/openvas/gnupg
+      - notus_data_vol:/var/lib/notus
+    # enable port forwarding when you want to use the http api from your host machine
+    # ports:
+    #   - 127.0.0.1:3000:80
+    depends_on:
+      vulnerability-tests:
+        condition: service_healthy
+      notus-data:
+        condition: service_healthy
+      configure-openvas:
+        condition: service_completed_successfully
+      gpg-data:
+        condition: service_completed_successfully
+    networks:
+      default:
+        aliases:
+          - openvasd
 
   ospd-openvas:
-    image: greenbone/ospd-openvas:stable
+    image: ghcr.io/shield-cyber/greenbone/ospd-openvas:2026-03-30
     restart: on-failure
-    init: true
     hostname: ospd-openvas.local
     cap_add:
       - NET_ADMIN # for capturing packages in promiscuous mode
@@ -148,12 +265,10 @@ services:
         "-f",
         "--config",
         "/etc/gvm/ospd-openvas.conf",
-        "--mqtt-broker-address",
-        "mqtt-broker",
         "--notus-feed-dir",
         "/var/lib/notus/advisories",
         "-m",
-        "666"
+        "666",
       ]
     volumes:
       - gpg_data_vol:/etc/openvas/gnupg
@@ -161,42 +276,22 @@ services:
       - notus_data_vol:/var/lib/notus
       - ospd_openvas_socket_vol:/run/ospd
       - redis_socket_vol:/run/redis/
+      - openvas_data_vol:/etc/openvas/
+      - openvas_log_data_vol:/var/log/openvas
     depends_on:
       redis-server:
         condition: service_started
       gpg-data:
         condition: service_completed_successfully
-      vulnerability-tests:
+      configure-openvas:
         condition: service_completed_successfully
-
-  mqtt-broker:
-    restart: on-failure
-    image: greenbone/mqtt-broker:latest
-    ports:
-      - 1883:1883
-    networks:
-      default:
-        aliases:
-          - mqtt-broker
-          - broker
-
-  notus-scanner:
-    restart: on-failure
-    image: greenbone/notus-scanner:stable
-    volumes:
-      - notus_data_vol:/var/lib/notus
-      - gpg_data_vol:/etc/openvas/gnupg
-    environment:
-      NOTUS_SCANNER_MQTT_BROKER_ADDRESS: mqtt-broker
-      NOTUS_SCANNER_PRODUCTS_DIRECTORY: /var/lib/notus/products
-    depends_on:
-      - mqtt-broker
-      - gpg-data
-      - vulnerability-tests
+      vulnerability-tests:
+        condition: service_healthy
+      notus-data:
+        condition: service_healthy
 
   gvm-tools:
-    image: greenbone/gvm-tools:latest
-    pull_policy: always
+    image: ghcr.io/shield-cyber/greenbone/gvm-tools:2026-03-30
     volumes:
       - gvmd_socket_vol:/run/gvmd
       - ospd_openvas_socket_vol:/run/ospd
@@ -204,15 +299,13 @@ services:
       - gvmd
       - ospd-openvas
 
-# Rest API
+# Rest API - commented out for devcontainer (run locally instead)
   # rest-api:
-  #   image: ghcr.io/shield-cyber/shieldcyber-rest-api:latest
+  #   image: ghcr.io/shield-cyber/shieldcyber-rest-api:3.0.62
   #   restart: on-failure
-  #   pull_policy: always
   #   ports:
   #     - 8000:8000
   #   environment:
-  #     - VERSION=0.0.0
   #     - PROD=False # Prod Mode, Only Used for Devs
   #     - USERNAME=admin # DEFAULT USERNAME 'admin'
   #     - PASSWORD=${PASSWORD:-admin} # SET ADMIN PASSWORD
@@ -223,7 +316,7 @@ services:
   #     - gvmd_socket_vol:/run/gvmd
   #     - api_logs_vol:/logs
 
-# Redis Database for Dev Rest API
+# Redis Database for Dev Rest API (with web UI)
   redis-db:
     image: redis/redis-stack:latest
     restart: on-failure
@@ -248,5 +341,10 @@ volumes:
   gvmd_socket_vol:
   ospd_openvas_socket_vol:
   redis_socket_vol:
+  openvas_data_vol:
+  openvas_log_data_vol:
+  gsa_data_vol:
+  nginx_config_vol:
+  nginx_certificates_vol:
   api_logs_vol:
   redis_data:

--- a/app/routes/report/report.py
+++ b/app/routes/report/report.py
@@ -56,6 +56,16 @@ async def get_report(
             return gmp.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=details)
         except Exception as err:
             LOGGER.error(f"GMP Error: {err}")
+            # Retry without details if the original request had details=True
+            # This handles the case where empty reports cause connection errors with details=True
+            if details:
+                LOGGER.warning(f"Retrying report {report_id} without details parameter")
+                try:
+                    with Gmp(connection=UnixSocketConnection()) as gmp_retry:
+                        gmp_retry.authenticate(username=current_user.username, password=Auth.get_admin_password())
+                        return gmp_retry.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=False)
+                except Exception as retry_err:
+                    LOGGER.error(f"GMP Error on retry: {retry_err}")
             return ErrorResponse("Internal Server Error")
 
 @ROUTER.get("/get/reports")

--- a/app/routes/report/report.py
+++ b/app/routes/report/report.py
@@ -3,7 +3,9 @@ from app.utils.auth import Auth
 from app.utils.xml import XMLResponse
 from app.utils.error import ErrorResponse
 from gvm.protocols.gmp import Gmp
+from gvm.errors import GvmError
 import logging
+import xml.etree.ElementTree as ET
 from gvm.connections import UnixSocketConnection
 from typing import Annotated, Optional, Union
 # from gvm.protocols.gmpv208.entities.report_formats import ReportFormatType
@@ -54,7 +56,7 @@ async def get_report(
         gmp.authenticate(username=current_user.username, password=Auth.get_admin_password())
         try:
             return gmp.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=details)
-        except Exception as err:
+        except GvmError as err:
             LOGGER.error(f"GMP Error: {err}")
             # Retry without details if the original request had details=True
             # This handles the case where empty reports cause connection errors with details=True
@@ -63,9 +65,31 @@ async def get_report(
                 try:
                     with Gmp(connection=UnixSocketConnection()) as gmp_retry:
                         gmp_retry.authenticate(username=current_user.username, password=Auth.get_admin_password())
-                        return gmp_retry.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=False)
+                        retry_response = gmp_retry.get_report(report_id=report_id, filter_string=filter_string, filter_id=filter_id, delta_report_id=delta_report_id, report_format_id=report_format_id, ignore_pagination=ignore_pagination, details=False)
+
+                        # VALIDATION: Check if report should have data
+                        root = ET.fromstring(retry_response)
+                        result_count_elem = root.find('.//result_count/filtered')
+                        hosts_count_elem = root.find('.//hosts/count')
+
+                        result_count = int(result_count_elem.text) if result_count_elem is not None else 0
+                        hosts_count = int(hosts_count_elem.text) if hosts_count_elem is not None else 0
+
+                        # If report indicates it should have data, throw the original error
+                        if result_count > 0 or hosts_count > 0:
+                            LOGGER.error(f"Report {report_id} has {result_count} results and {hosts_count} hosts but failed with details=True. Original error: {err}")
+                            return ErrorResponse("Internal Server Error")
+
+                        # Report is genuinely empty, safe to return details=False version
+                        LOGGER.info(f"Report {report_id} confirmed empty (0 results, 0 hosts), returning summary")
+                        return retry_response
+
                 except Exception as retry_err:
                     LOGGER.error(f"GMP Error on retry: {retry_err}")
+            return ErrorResponse("Internal Server Error")
+        except Exception as err:
+            # Non-GVM errors
+            LOGGER.error(f"Unexpected error: {err}")
             return ErrorResponse("Internal Server Error")
 
 @ROUTER.get("/get/reports")


### PR DESCRIPTION
## Problem
Reports with 0 findings caused "Remote closed the connection" errors when accessed via the REST API endpoint `/report/get/report/{report_id}`, returning HTTP 500 to users.

## Root Cause
When `gmp.get_report()` is called with `details=True` on an empty report (0 findings), gvmd closes the connection. This is a known issue with python-gvm v26.10.1 and gvmd.

## Solution
Implemented validated retry logic with automatic fallback to `details=False` when connection errors occur on empty reports:

1. **First attempt**: Call `gmp.get_report()` with `details=True` (default)
2. **On GvmError**: Automatically retry with `details=False`
3. **Validation**: Parse XML response to check `result_count` and `hosts` count
4. **Safety check**: If report should have data (count > 0), return error instead of incomplete summary
5. **Empty report confirmed**: Return summary response only if genuinely empty (0 results, 0 hosts)

### Key Safety Feature
The validation prevents false negatives where the API could fail for reasons other than empty reports. If a report indicates it should have vulnerability data but failed with `details=True`, the endpoint returns an error rather than silently returning incomplete summary data.

## Changes

### app/routes/report/report.py
- Added `GvmError` and `xml.etree.ElementTree` imports for specific error handling and XML parsing
- Changed from generic `Exception` to specific `GvmError` for GVM-specific errors
- Implemented validated retry logic (lines 56-93):
  - Retry with `details=False` on GvmError
  - Parse XML to extract `result_count/filtered` and `hosts/count`
  - Return error if report should have data (prevents false negatives)
  - Return summary only if confirmed empty (0 results, 0 hosts)
- Enhanced logging with validation details
- Added separate exception handler for non-GVM errors

### .devcontainer/compose.yml
- Updated all Greenbone container images from `greenbone/` to `ghcr.io/shield-cyber/greenbone/` with `2026-03-30` tag
- Added new services: `pg-gvm-migrator`, `gsa`, `gsad`, `nginx`, `gvm-config`, `openvasd`
- Removed deprecated services: `mqtt-broker`, `notus-scanner`
- Updated volumes to match production environment

## Backward Compatibility
✅ Maintains `details=True` as default parameter  
✅ No API changes required for existing clients  
✅ Transparent fallback - users get valid responses with proper error handling  

## Testing
✅ **Empty report** (a8885dbd-44d6-4ecf-9e83-abb42875314d): Returns HTTP 200 with summary after validation confirms 0 results, 0 hosts  
✅ **Report with findings** (30ddfe99-0165-4fdd-a7c3-c0868b25d3ee): Returns HTTP 200 with full details, no retry triggered  
✅ **Validation logic**: Prevents false negatives by checking if report should have data before returning summary  

## Log Evidence
```
WARNING: Retrying report a8885dbd-44d6-4ecf-9e83-abb42875314d without details parameter
INFO: Report a8885dbd-44d6-4ecf-9e83-abb42875314d confirmed empty (0 results, 0 hosts), returning summary
```

If a report fails with details=True but should have data:
```
ERROR: Report {id} has {N} results and {M} hosts but failed with details=True. Original error: {err}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)